### PR TITLE
make sure stdc++ is linked

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ Currently, the combinations of following options are supported:
 - `distance metric`: {__L1__, __L2__}
 
 ### quick start
+__install with pip:__  
+```
+pip install --upgrade pip
+pip install napf
+```
+_Note: in case your system requires a dynamic build, you need a c++11 compatible c++ compiler. To make sure a correct compiler is chosen, set `export CC=<your-c-compiler> CXX=<your-c++-compiler>`_
+
 ```python
 import napf
 import numpy as np

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 with open("README.md", "r") as f:
     readme = f.read()
 
-__version__ = "0.0.0"
+__version__ = "0.0.1"
 
 ext_modules = [
     Pybind11Extension(
@@ -20,6 +20,7 @@ ext_modules = [
         include_dirs=["third_party"],
         extra_compile_args=["-O3"],
         cxx_std=11,
+        libraries=["stdc++"],
     )
 ]
 


### PR DESCRIPTION
# Overview
changes to avoid `undefined symbol: _ZTVN10__cxxabiv117__class_type_infoE` error on linux
