### PR TITLE
remove source from interface library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(namespace "${PROJECT_NAME}::")
 set(CXX_HEADERS src/napf.hpp third_party/nanoflann.hpp)
 
 # Interface Library, since it's header only lib
-add_library(napf INTERFACE ${CXX_HEADERS})
+add_library(napf INTERFACE)
 add_library(napf::napf ALIAS napf)
 target_include_directories(napf
     INTERFACE


### PR DESCRIPTION
# Overview
Defining sources in interface library is supported from [cmake 3.19+](https://cmake.org/cmake/help/latest/command/add_library.html#interface-libraries).  
It is not strictly necessary to do so, so rm.