### PR TITLE
Add CI and CD to napf repository

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -26,7 +26,7 @@ jobs:
         pip install setuptools wheel
         pip install pybind11
     
-    - name: Build package with ubuntu 20.04
+    - name: Build napf
       run: |
         pip install numpy
         python setup.py develop

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,8 +1,7 @@
 name: install and testing
 
 on:
-  push:
-    branches: ["main", "ft-add-ci"]
+  push
 
 jobs:
   build_and_test:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -25,6 +25,7 @@ jobs:
         pip install numpy
         pip install setuptools wheel
         pip install pybind11
+        pip install pytest
     
     - name: Build napf
       run: |
@@ -32,4 +33,4 @@ jobs:
         python setup.py develop
 
     - name: Test
-      run: python -m unittest discover
+      run: pytest tests

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,11 +28,12 @@ jobs:
     
     - name: Build package with ubuntu 20.04
       if: (matrix.os == 'ubuntu-20.04' && matrix.python-version == '3.7')
-      run: python setup.py install
+      run: |
+        python setup.py install
+        python -m unittest discover
       
     - name: Build package with ubuntu 22.04
       if: (matrix.os != 'ubuntu-20.04' && matrix.python-version != '3.7')
-      run: python setup.py develop
-      
-    - name: Test
-      run: python -m unittest discover
+      run: | 
+        python setup.py develop
+        python -m unittest discover

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,7 +28,7 @@ jobs:
     
     - name: Build package with ubuntu 20.04
       if: (matrix.os == 'ubuntu-20.04' && matrix.python-version == '3.7')
-      run: python setup.py develop
+      run: python setup.py install
       
     - name: Build package with ubuntu 22.04
       if: (matrix.os != 'ubuntu-20.04' && matrix.python-version != '3.7')

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,7 +27,7 @@ jobs:
         pip install pybind11
     
     - name: Build package with ubuntu 20.04
-      if: (matrix.os == 'ubuntu-20.04' && matrix.python-version == "3.7")
+      if: (matrix.os == 'ubuntu-20.04' && matrix.python-version == '3.7')
       run: python setup.py develop
       
     - name: Build package with ubuntu 22.04

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [macos-latest, ubuntu-latest]
 
     steps:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [macos-latest, ubuntu-latest]
 
     steps:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7.15", "3.8", "3.9", "3.10", "3.11"]
-        os: [macos-latest, ubuntu-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        os: [macos-latest, ubuntu-latest, ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v3
@@ -19,14 +19,20 @@ jobs:
       with:
         python-version: ${{ matrix.python-version}}
     - name: Install dependencies
+     
       run: |
         python -m pip install --upgrade pip
         pip install build
         pip install setuptools wheel
         pip install pybind11
     
-    - name: Build package
+    - name: Build package with ubuntu 20.04
+      if: (matrix.os == 'ubuntu-20.04' && matrix.python-version == "3.7")
       run: python setup.py develop
+      
+    - name: Build package with ubuntu 22.04:
+      if: (matrix.os != 'ubuntu-20.04' && matrix.python-version != '3.7')
+      run python setup.py develop
       
     - name: Test
       run: python -m unittest discover

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [macos-latest, ubuntu-latest]
 
     steps:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        os: [macos-latest, ubuntu-latest, ubuntu-20.04]
+        os: [macos-latest, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v3
@@ -23,18 +23,14 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build
+        pip install numpy
         pip install setuptools wheel
         pip install pybind11
     
     - name: Build package with ubuntu 20.04
-      if: (matrix.os == 'ubuntu-20.04' && matrix.python-version == '3.7')
       run: |
         pip install numpy
         python setup.py install
-        python -m unittest discover
-      
-    - name: Build package with ubuntu 22.04
-      if: (matrix.os != 'ubuntu-20.04' && matrix.python-version != '3.7')
-      run: | 
-        python setup.py develop
-        python -m unittest discover
+
+    - name: Test
+      run: python -m unittest discover

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,6 +29,7 @@ jobs:
     - name: Build package with ubuntu 20.04
       if: (matrix.os == 'ubuntu-20.04' && matrix.python-version == '3.7')
       run: |
+        pip install numpy
         python setup.py install
         python -m unittest discover
       

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,7 +22,7 @@ jobs:
         pip install pybind11
     
     - name: Build package
-      run: python setup.py install
+      run: python setup.py develop
       
     - name: Test
       run: python -m unittest discover

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,14 +6,18 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
+        os: [macos-latest, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.10'
+        python-version: ${{ matrix.python-version}}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [macos-latest, ubuntu-latest]
 
     steps:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,28 @@
+name: install and testing
+
+on:
+  push:
+    branches: ["main", "ft-add-ci"]
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+        pip install setuptools wheel
+        pip install pybind11
+    
+    - name: Build package
+      run: python setup.py install
+      
+    - name: Test
+      run: python -m unittest discover

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Build package with ubuntu 20.04
       run: |
         pip install numpy
-        python setup.py install
+        python setup.py develop
 
     - name: Test
       run: python -m unittest discover

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -30,9 +30,9 @@ jobs:
       if: (matrix.os == 'ubuntu-20.04' && matrix.python-version == "3.7")
       run: python setup.py develop
       
-    - name: Build package with ubuntu 22.04:
+    - name: Build package with ubuntu 22.04
       if: (matrix.os != 'ubuntu-20.04' && matrix.python-version != '3.7')
-      run python setup.py develop
+      run: python setup.py develop
       
     - name: Test
       run: python -m unittest discover

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7.15", "3.8", "3.9", "3.10", "3.11"]
         os: [macos-latest, ubuntu-latest]
 
     steps:

--- a/.github/workflows/upload_wheels.yml
+++ b/.github/workflows/upload_wheels.yml
@@ -1,0 +1,38 @@
+name: build full and pypi upload
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  wheel_build_full:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - name: build wheels
+      uses: pypa/cibuildwheel@v2.11.1
+
+    - uses: actions/upload-artifact@v3
+      with:
+        path: ./wheelhouse/*.whl
+
+  upload_pypi:
+    needs: [wheel_build_full]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+        name: artifact
+        path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.6.1
+        with:
+        skip_existing: true
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Add github actions to the repository for CI and CD.
For every push napf is build and test with pytest in different python versions and OS (macOS and ubuntu). 
Pushing on the main branch triggers the CD - workflow. The CD create wheels for macOS and ubuntu with different python versions and upload it to [PyPI](https://pypi.org/search/?q=tataratat)