### PR TITLE
thread safe, update nanoflann

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,225 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterExternBlock: false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAfterAttributes: Never
+BreakAfterJavaFieldAnnotations: false
+BreakArrays:     true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Attach
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: BinPack
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+PPIndentWidth:   -1
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
+...
+

--- a/.clang-format
+++ b/.clang-format
@@ -4,64 +4,41 @@ Language:        Cpp
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
 AlignArrayOfStructures: None
-AlignConsecutiveAssignments:
-  Enabled:         false
-  AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCompound:   false
-  PadOperators:    true
-AlignConsecutiveBitFields:
-  Enabled:         false
-  AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCompound:   false
-  PadOperators:    false
-AlignConsecutiveDeclarations:
-  Enabled:         false
-  AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCompound:   false
-  PadOperators:    false
-AlignConsecutiveMacros:
-  Enabled:         false
-  AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCompound:   false
-  PadOperators:    false
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
 AlignEscapedNewlines: Right
-AlignOperands:   Align
-AlignTrailingComments:
-  Kind:            Always
-  OverEmptyLines:  0
-AllowAllArgumentsOnNextLine: true
-AllowAllParametersOfDeclarationOnNextLine: true
+AlignOperands: Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortEnumsOnASingleLine: true
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortEnumsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: Never
 AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: MultiLine
+AlwaysBreakTemplateDeclarations: Yes
 AttributeMacros:
   - __capability
-BinPackArguments: true
-BinPackParameters: true
-BitFieldColonSpacing: Both
+BinPackArguments: false
+BinPackParameters: false
 BraceWrapping:
   AfterCaseLabel:  false
   AfterClass:      false
   AfterControlStatement: Never
   AfterEnum:       false
-  AfterExternBlock: false
   AfterFunction:   false
   AfterNamespace:  false
   AfterObjCDeclaration: false
   AfterStruct:     false
   AfterUnion:      false
+  AfterExternBlock: false
   BeforeCatch:     false
   BeforeElse:      false
   BeforeLambdaBody: false
@@ -70,28 +47,33 @@ BraceWrapping:
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
-BreakAfterAttributes: Never
-BreakAfterJavaFieldAnnotations: false
-BreakArrays:     true
-BreakBeforeBinaryOperators: None
-BreakBeforeConceptDeclarations: Always
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeConceptDeclarations: true
 BreakBeforeBraces: Attach
-BreakBeforeInlineASMColon: OnlyMultiline
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializers: BeforeColon
+BreakBeforeInheritanceComma: false
 BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
 CompactNamespaces: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
+DeriveLineEnding: true
 DerivePointerAlignment: false
 DisableFormat:   false
 EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: CurrentLine
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
 FixNamespaceComments: true
 ForEachMacros:
   - foreach
@@ -116,29 +98,19 @@ IncludeCategories:
 IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''
 IndentAccessModifiers: false
-IndentCaseBlocks: false
 IndentCaseLabels: false
-IndentExternBlock: AfterExternBlock
+IndentCaseBlocks: false
 IndentGotoLabels: true
 IndentPPDirectives: None
-IndentRequiresClause: true
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
 IndentWidth:     2
 IndentWrappedFunctionNames: false
-InsertBraces:    false
-InsertNewlineAtEOF: false
 InsertTrailingCommas: None
-IntegerLiteralSeparator:
-  Binary:          0
-  BinaryMinDigits: 0
-  Decimal:         0
-  DecimalMinDigits: 0
-  Hex:             0
-  HexMinDigits:    0
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: true
 LambdaBodyIndentation: Signature
-LineEnding:      DeriveLF
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
@@ -148,7 +120,6 @@ ObjCBlockIndentWidth: 2
 ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
-PackConstructorInitializers: BinPack
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
@@ -157,26 +128,21 @@ PenaltyBreakOpenParenthesis: 0
 PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
-PenaltyIndentedWhitespace: 0
 PenaltyReturnTypeOnItsOwnLine: 60
-PointerAlignment: Right
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Left
 PPIndentWidth:   -1
-QualifierAlignment: Leave
 ReferenceAlignment: Pointer
 ReflowComments:  true
 RemoveBracesLLVM: false
-RemoveSemicolon: false
-RequiresClausePosition: OwnLine
-RequiresExpressionIndentation: OuterScope
 SeparateDefinitionBlocks: Leave
 ShortNamespaceLines: 1
 SortIncludes:    CaseSensitive
 SortJavaStaticImport: Before
-SortUsingDeclarations: LexicographicNumeric
-SpaceAfterCStyleCast: false
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: true
 SpaceAfterLogicalNot: false
-SpaceAfterTemplateKeyword: true
-SpaceAroundPointerQualifiers: Default
+SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
@@ -190,11 +156,9 @@ SpaceBeforeParensOptions:
   AfterFunctionDeclarationName: false
   AfterIfMacros:   true
   AfterOverloadedOperator: false
-  AfterRequiresInClause: false
-  AfterRequiresInExpression: false
   BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
 SpaceBeforeRangeBasedForLoopColon: true
-SpaceBeforeSquareBrackets: false
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
@@ -207,6 +171,8 @@ SpacesInLineCommentPrefix:
   Maximum:         -1
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
 Standard:        Latest
 StatementAttributeLikeMacros:
   - Q_EMIT
@@ -214,12 +180,12 @@ StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
 TabWidth:        8
+UseCRLF:         false
 UseTab:          Never
 WhitespaceSensitiveMacros:
-  - BOOST_PP_STRINGIZE
-  - CF_SWIFT_NAME
-  - NS_SWIFT_NAME
-  - PP_STRINGIZE
   - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
 ...
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,9 @@ repos:
   hooks:
   - id: flake8
     args: [--extend-ignore=E203]
+
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v16.0.4
+  hooks:
+  - id: clang-format
+    types_or: [c++]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,8 @@ ci:
   autoupdate_schedule: "monthly"
   submodules: false
 
+exclude: "third_party/nanoflann.hpp"
+
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: "v4.4.0"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Currently, the combinations of following options are supported:
 - `data type`: {__double__, __float__, __int__, __long__}  _(corresponds to {np.float64, np.float32, np.int32, np.int64})_
 - `data dimension`: {__1__, __2__, __3__, __4__, __5__, __6__, __7__, __8__, __9__, __10__, __11__, __12__, __13__, __14__, __15__, __16__, __17__, __18__, __19__, __20__}
 - `distance metric`: {__L1__, __L2__}
+Note that functions return squared distances, when you use the __L2__ metric.
 
 ### quick start
 __install with pip:__

--- a/napf/__init__.py
+++ b/napf/__init__.py
@@ -1,13 +1,13 @@
 from napf import _napf
 from napf import _napf as core
 from napf import base
+from napf._version import version as __version__
 from napf.base import (
     KDT,
     core_class_str_and_data,
     np2napf_dtypes,
     validate_metric_input,
 )
-from napf._version import version as __version__
 
 __all__ = [
     "_napf",

--- a/napf/_version.py
+++ b/napf/_version.py
@@ -1,1 +1,1 @@
-version = "0.0.4"
+version = "0.0.5"

--- a/napf/base.py
+++ b/napf/base.py
@@ -417,9 +417,26 @@ class _KDT:
         if nthread is None:
             nthread = self.nthread
 
-        return self.core_tree.unique_data_and_inverse(
-            radius, return_unique, return_intersection, nthread
+        (
+            original_inverse,
+            intersection,
+        ) = self.core_tree.tree_data_unique_inverse(
+            radius, return_intersection, nthread
         )
+
+        unique_ids, inverse_ids = np.unique(
+            original_inverse, return_inverse=True
+        )
+
+        if return_unique:
+            return (
+                self.core_tree.tree_data[unique_ids],
+                unique_ids,
+                inverse_ids,
+                intersection,
+            )
+        else:
+            return np.array(), unique_ids, inverse_ids, intersection
 
 
 def KDT(tree_data, metric=2, leaf_size=10, nthread=1):

--- a/napf/base.py
+++ b/napf/base.py
@@ -314,6 +314,34 @@ class _KDT:
             nthread,
         )
 
+    def query_ball_point(self, queries, radius, return_sorted, nthread=None):
+        """
+        scipy-like KDTree query_ball_point call.
+
+        Parameters
+        ----------
+        queries: (m, d) np.ndarray
+          Data type will be casted to the same type as `tree_data`.
+        radius: float
+        return_sorted: bool
+        nthread: int
+          Default is None and will use self.nthread
+
+        Returns
+        -------
+        ids: list
+          list of np.array
+        """
+        if nthread is None:
+            nthread = self.nthread
+
+        return self.core_tree.query_ball_point(
+            enforce_contiguous(queries, self.dtype),
+            radius,
+            return_sorted,
+            nthread,
+        )
+
     def radii_search(self, queries, radii, return_sorted, nthread=None):
         """
         Similar to `radius_search`, but you can specify radius for each query.

--- a/napf/base.py
+++ b/napf/base.py
@@ -114,7 +114,7 @@ class _KDT:
         "_dtype",
     )
 
-    def __init__(self, tree_data, metric=2, nthread=1):
+    def __init__(self, tree_data, metric=2, leaf_size=10, nthread=1):
         """
         _KDT init. Given tree_data, creates corresponding core kdt class.
         Tree is initialized using `newtree()`.
@@ -125,6 +125,7 @@ class _KDT:
         tree_data: (n, d) np.ndarray
           {double, float, int, long}
           Readonly tree data. saved with `newtree()`
+        leaf_size:int
         nthread: int
           Default value for nthreads.
 
@@ -133,7 +134,7 @@ class _KDT:
         tree_data: (n, d) np.ndarray
           {double, float, int, long}
         """
-        self.newtree(tree_data, metric)
+        self.newtree(tree_data, metric, leaf_size, nthread)
         self.nthread = nthread
 
     @property
@@ -213,7 +214,7 @@ class _KDT:
         """
         return self._dtype
 
-    def newtree(self, tree_data, metric=2):
+    def newtree(self, tree_data, metric=2, leaf_size=10, nthread=1):
         """
         Given 2D array-like tree_data, it:
           1. makes sure data is a contiguous array
@@ -232,7 +233,7 @@ class _KDT:
         # we can call newtree() function of the core class,
         # if _core_tree already exists.
         # However, creating a new kdt should not add significant overhead.
-        self._core_tree = eval(f"core.{core_cls}(tdata)")
+        self._core_tree = eval(f"core.{core_cls}(tdata, leaf_size, nthread)")
         self._dtype = tdata.dtype
 
     def knn_search(self, queries, kneighbors, nthread=None):
@@ -380,14 +381,14 @@ class _KDT:
         )
 
 
-def KDT(tree_data, metric=2):
+def KDT(tree_data, metric=2, leaf_size=10, nthread=1):
     """
     Factory like initializer for KDT.
     `napf` is implemented as template, thus, there are separate classes
     for each {data_type, dim, metric}.
     Currently following combinations are supported:
     data_type: {double, int}
-    dim: {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+    dim: {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
     metric: {L1, L2}
 
     Parameters
@@ -397,6 +398,9 @@ def KDT(tree_data, metric=2):
     metric: int or str
       Default is 2 and distance will be a squared euklidian distance.
       Valid options are {1, l1, L1, 2, l2, L2}.
+    leaf_size: int
+    nthread: int
+      Default thread count for all multi-thread-
 
 
     Returns
@@ -405,4 +409,4 @@ def KDT(tree_data, metric=2):
     """
     tdata = np.ascontiguousarray(tree_data)
 
-    return _KDT(tdata, metric)
+    return _KDT(tdata, metric, leaf_size, nthread)

--- a/napf/base.py
+++ b/napf/base.py
@@ -380,6 +380,47 @@ class _KDT:
             nthread,
         )
 
+    def unique_data_and_inverse(
+        self,
+        radius,
+        return_unique=True,
+        return_intersection=True,
+        nthread=None,
+    ):
+        """
+        Finds unique tree data with in given radius tolerance.
+
+        Paramters
+        ---------
+        radius: float
+        return_unique: bool
+          Default is True. Otherwise, will be an empty array return.
+        return_intersection: bool
+          Default is True, Otherwise, will be an empty UIntVectorVector return.
+        nthread:int
+
+        Returns
+        -------
+        unique_data: np.ndarray
+          Empty if return_unique is False.
+          Same as kdt.tree_data[unique_ids].
+        unique_ids: np.ndarray
+          Indices of unique entries from tree data.
+          First occurance is considered unique.
+        inverse_ids: np.ndarray
+          Indices to reconstruct original tree_data with
+          unique_data. kdt.tree_data == unique_data[inverse_ids]
+        intersection: UIntVectorVector
+          Empty if return_intersection is False.
+          Intersection of each data with respect to all the others.
+        """
+        if nthread is None:
+            nthread = self.nthread
+
+        return self.core_tree.unique_data_and_inverse(
+            radius, return_unique, return_intersection, nthread
+        )
+
 
 def KDT(tree_data, metric=2, leaf_size=10, nthread=1):
     """
@@ -388,7 +429,8 @@ def KDT(tree_data, metric=2, leaf_size=10, nthread=1):
     for each {data_type, dim, metric}.
     Currently following combinations are supported:
     data_type: {double, int}
-    dim: {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
+    dim:
+      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
     metric: {L1, L2}
 
     Parameters

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ ext_modules = [
     Pybind11Extension(
         "napf._napf",
         [
+            "src/python/classes/radius_search_result_vectors.cpp",
             "src/python/classes/int_trees.cpp",
             "src/python/classes/long_trees.cpp",
             "src/python/classes/float_trees.cpp",

--- a/src/napf.hpp
+++ b/src/napf.hpp
@@ -103,8 +103,8 @@ public:
       return pts()[id];
     } else {
 
-    // cast here to allow both SplineLib and BezMan coordinates types.
-    return static_cast<double>(pts()[id][q_dim]);
+      // cast here to allow both SplineLib and BezMan coordinates types.
+      return static_cast<double>(pts()[id][q_dim]);
     }
   }
 

--- a/src/napf.hpp
+++ b/src/napf.hpp
@@ -16,7 +16,7 @@ public:
   inline size_t kdtree_get_point_count() const { return ptrlen_ / dim_; }
 
   inline PointT kdtree_get_pt(const IndexT q_ind, const IndexT q_dim) const {
-    return points_[q_ind * dim + q_dim];
+    return points_[q_ind * dim_ + q_dim];
   }
 
   template<class BBOX>

--- a/src/python/classes/double_trees.cpp
+++ b/src/python/classes/double_trees.cpp
@@ -41,5 +41,4 @@ void init_double_trees(py::module_& m) {
   add_kdt_pyclass<double, 19, 2>(m, "KDTdD19L2");
   add_kdt_pyclass<double, 20, 1>(m, "KDTdD20L1");
   add_kdt_pyclass<double, 20, 2>(m, "KDTdD20L2");
-
 }

--- a/src/python/classes/double_trees.cpp
+++ b/src/python/classes/double_trees.cpp
@@ -1,5 +1,7 @@
 #include "../pykdt.hpp"
 
+namespace napf {
+
 void init_double_trees(py::module_& m) {
   add_kdt_pyclass<double, 1, 1>(m, "KDTdD1L1");
   add_kdt_pyclass<double, 1, 2>(m, "KDTdD1L2");
@@ -41,4 +43,6 @@ void init_double_trees(py::module_& m) {
   add_kdt_pyclass<double, 19, 2>(m, "KDTdD19L2");
   add_kdt_pyclass<double, 20, 1>(m, "KDTdD20L1");
   add_kdt_pyclass<double, 20, 2>(m, "KDTdD20L2");
+}
+
 }

--- a/src/python/classes/float_trees.cpp
+++ b/src/python/classes/float_trees.cpp
@@ -1,5 +1,7 @@
 #include "../pykdt.hpp"
 
+namespace napf {
+
 void init_float_trees(py::module_& m) {
   add_kdt_pyclass<float, 1, 1>(m, "KDTfD1L1");
   add_kdt_pyclass<float, 1, 2>(m, "KDTfD1L2");
@@ -42,3 +44,5 @@ void init_float_trees(py::module_& m) {
   add_kdt_pyclass<float, 20, 1>(m, "KDTfD20L1");
   add_kdt_pyclass<float, 20, 2>(m, "KDTfD20L2");
 }
+
+} // namespace napf

--- a/src/python/classes/int_trees.cpp
+++ b/src/python/classes/int_trees.cpp
@@ -1,5 +1,7 @@
 #include "../pykdt.hpp"
 
+namespace napf {
+
 void init_int_trees(py::module_& m) {
   add_kdt_pyclass<int32_t, 1, 1>(m, "KDTiD1L1");
   add_kdt_pyclass<int32_t, 1, 2>(m, "KDTiD1L2");
@@ -42,3 +44,5 @@ void init_int_trees(py::module_& m) {
   add_kdt_pyclass<int32_t, 20, 1>(m, "KDTiD20L1");
   add_kdt_pyclass<int32_t, 20, 2>(m, "KDTiD20L2");
 }
+
+} // namespace napf

--- a/src/python/classes/long_trees.cpp
+++ b/src/python/classes/long_trees.cpp
@@ -1,5 +1,7 @@
 #include "../pykdt.hpp"
 
+namespace napf {
+
 void init_long_trees(py::module_& m) {
   add_kdt_pyclass<int64_t, 1, 1>(m, "KDTlD1L1");
   add_kdt_pyclass<int64_t, 1, 2>(m, "KDTlD1L2");
@@ -42,3 +44,5 @@ void init_long_trees(py::module_& m) {
   add_kdt_pyclass<int64_t, 20, 1>(m, "KDTlD20L1");
   add_kdt_pyclass<int64_t, 20, 2>(m, "KDTlD20L2");
 }
+
+} // namespace napf

--- a/src/python/classes/radius_search_result_vectors.cpp
+++ b/src/python/classes/radius_search_result_vectors.cpp
@@ -1,0 +1,18 @@
+#include "../pykdt.hpp"
+
+#include <pybind11/stl_bind.h>
+
+namespace napf {
+
+namespace py = pybind11;
+
+void init_radius_search_result_vector(py::module_& m) {
+  py::bind_vector<FloatVector>(m, "FloatVector");
+  py::bind_vector<FloatVectorVector>(m, "FloatVectorVector");
+  py::bind_vector<DoubleVector>(m, "DoubleVector");
+  py::bind_vector<DoubleVectorVector>(m, "DoubleVectorVector");
+  py::bind_vector<UIntVector>(m, "UIntVector");
+  py::bind_vector<UIntVectorVector>(m, "UIntVectorVector");
+}
+
+}

--- a/src/python/napf.cpp
+++ b/src/python/napf.cpp
@@ -2,14 +2,20 @@
 
 namespace py = pybind11;
 
+namespace napf {
+
 void init_int_trees(py::module_&);
 void init_long_trees(py::module_&);
 void init_float_trees(py::module_&);
 void init_double_trees(py::module_&);
+void init_radius_search_result_vector(py::module_&);
+
+} // namespace napf
 
 PYBIND11_MODULE(_napf, m) {
-  init_int_trees(m);
-  init_long_trees(m);
-  init_float_trees(m);
-  init_double_trees(m);
+  napf::init_int_trees(m);
+  napf::init_long_trees(m);
+  napf::init_float_trees(m);
+  napf::init_double_trees(m);
+  napf::init_radius_search_result_vector(m);
 }

--- a/src/python/threadhelper.hpp
+++ b/src/python/threadhelper.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cmath>
+#include <algorithm>
 #include <thread>
 
 namespace napf {
@@ -9,22 +9,33 @@ namespace napf {
 template<typename Func, typename IndexT>
 void nthread_execution(Func& f, IndexT& total, IndexT& nthread) {
   // if nthread == 1, don't even bother creating thread
-  if (nthread == 1) {
+  if (nthread == 1 || nthread == 0) {
     f(0, total);
     return;
   }
 
-  // get chunk size and prepare threads
-  const IndexT chunk_size = (total + nthread - 1) / nthread;
-  std::vector<std::thread> tpool;
-  tpool.reserve(nthread);
+  int n_usable_threads{nthread};
 
-  for (int i{0}; i < (nthread - 1); i++) {
+  // negative input looks for hardware_concurrency
+  if (nthread < 0) {
+    n_usable_threads = std::max(std::thread::hardware_concurrency(), 1u);
+  }
+
+  // thread shouldn't exceed total
+  n_usable_threads = std::min(total, n_usable_threads);
+
+  // get chunk size and prepare threads
+  const IndexT chunk_size = (total + n_usable_threads - 1) / n_usable_threads;
+  std::vector<std::thread> tpool;
+  tpool.reserve(n_usable_threads);
+
+  for (int i{0}; i < (n_usable_threads - 1); i++) {
     tpool.emplace_back(std::thread{f, i * chunk_size, (i + 1) * chunk_size});
   }
   {
     // last one
-    tpool.emplace_back(std::thread{f, (nthread - 1) * chunk_size, total});
+    tpool.emplace_back(
+        std::thread{f, (n_usable_threads - 1) * chunk_size, total});
   }
 
   for (auto& t : tpool) {

--- a/src/python/threadhelper.hpp
+++ b/src/python/threadhelper.hpp
@@ -3,6 +3,8 @@
 #include <cmath>
 #include <thread>
 
+namespace napf {
+
 /* thread for all */
 template<typename Func, typename IndexT>
 void nthread_execution(Func& f, IndexT& total, IndexT& nthread) {
@@ -29,3 +31,5 @@ void nthread_execution(Func& f, IndexT& total, IndexT& nthread) {
     t.join();
   }
 }
+
+} // namespace napf

--- a/src/python/threadhelper.hpp
+++ b/src/python/threadhelper.hpp
@@ -5,12 +5,11 @@
 
 namespace napf {
 
-/* thread for all */
 template<typename Func, typename IndexT>
-void nthread_execution(Func& f, IndexT& total, IndexT& nthread) {
+void nthread_execution(Func& f, const IndexT total, const IndexT nthread) {
   // if nthread == 1, don't even bother creating thread
   if (nthread == 1 || nthread == 0) {
-    f(0, total);
+    f(0, total, 0);
     return;
   }
 
@@ -30,12 +29,14 @@ void nthread_execution(Func& f, IndexT& total, IndexT& nthread) {
   tpool.reserve(n_usable_threads);
 
   for (int i{0}; i < (n_usable_threads - 1); i++) {
-    tpool.emplace_back(std::thread{f, i * chunk_size, (i + 1) * chunk_size});
+    tpool.emplace_back(std::thread{f, i * chunk_size, (i + 1) * chunk_size, i});
   }
   {
     // last one
-    tpool.emplace_back(
-        std::thread{f, (n_usable_threads - 1) * chunk_size, total});
+    tpool.emplace_back(std::thread{f,
+                                   (n_usable_threads - 1) * chunk_size,
+                                   total,
+                                   n_usable_threads - 1});
   }
 
   for (auto& t : tpool) {


### PR DESCRIPTION
# Overview
- fixes thread-unsafe `radius_search` and `radii_search`
- adds `std::vector<T>` classes with `py::bind_vector`. this is a return type for radius searches.
- format
- add `query_ball_point`, similar to `scipy`'s API
- fixes #17 
- update nanoflann
- add `leaf_size` param for init
- add `nthread` param for init -> used for concurrent tree build
- adds `unique_data_and_inverse()`