### PR TITLE
Fix: visually broken links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 [![main](https://github.com/tataratat/napf/actions/workflows/main.yml/badge.svg)](https://github.com/tataratat/napf/actions/workflows/main.yml)
 [![PyPI version](https://badge.fury.io/py/napf.svg)](https://badge.fury.io/py/napf)
 
-[`nanoflann`](https://github.com/jlblancoc/nanoflann) wrappers for python and maybe fortran.
+[nanoflann](https://github.com/jlblancoc/nanoflann) wrappers for python and maybe fortran.
 
 ## python
-As `nanoflann` offers template classes, separate classes are implemented in `napf` for each ___{datatype, data dimension, distance metric}___. All the search functions are equipped with multi-thread execution. Uses [`numpy.ndarray`](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html) for data input and output.
+As `nanoflann` offers template classes, separate classes are implemented in `napf` for each ___{datatype, data dimension, distance metric}___. All the search functions are equipped with multi-thread execution. Uses [numpy.ndarray](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html) for data input and output.
 Currently, the combinations of following options are supported:
 - `data type`: {__double__, __float__, __int__, __long__}  _(corresponds to {np.float64, np.float32, np.int32, np.int64})_
 - `data dimension`: {__1__, __2__, __3__, __4__, __5__, __6__, __7__, __8__, __9__, __10__, __11__, __12__, __13__, __14__, __15__, __16__, __17__, __18__, __19__, __20__}
@@ -39,3 +39,15 @@ indices, distances = kdt.knn_search(
 
 ## fortran
 maybe...
+
+
+## Documentation
+This package uses a `sphinx` based documentation. An online version of the documentation can be found at [napf - documentation](https://tataratat.github.io/napf/).
+
+If you want to build the documentation yourself use the following commands in the package root directory.
+```bash
+pip install -r ./docs/requirements.txt
+sphinx-build -W -b html docs/source docs/build -j auto
+```
+
+You will find the documentation in the docs/build folder.


### PR DESCRIPTION
In the documentation there are some visually broken links. These are on the index page, which is the README of the project.

The reason behind this is formatting of the link text in the README document which gets mangled during the docs build.

Fixed by removing the formatting of the link text.


I used this opportunity to also add a section to the README on how the documentation can be build. 