### PR TITLE
Rm coordinates and dim as tparam

### DIFF
--- a/napf/base.py
+++ b/napf/base.py
@@ -97,10 +97,9 @@ def core_class_str_and_data(tree_data, metric):
 
     # extract info
     data_t = np2napf_dtypes[dtypestr]
-    dim = arr.shape[1]
     metric = validate_metric_input(metric)
 
-    return f"KDT{data_t}D{dim}L{metric}", arr
+    return f"KDT{data_t}L{metric}", arr
 
 
 class KDT:

--- a/src/python/classes/double_trees.cpp
+++ b/src/python/classes/double_trees.cpp
@@ -3,46 +3,8 @@
 namespace napf {
 
 void init_double_trees(py::module_& m) {
-  add_kdt_pyclass<double, 1, 1>(m, "KDTdD1L1");
-  add_kdt_pyclass<double, 1, 2>(m, "KDTdD1L2");
-  add_kdt_pyclass<double, 2, 1>(m, "KDTdD2L1");
-  add_kdt_pyclass<double, 2, 2>(m, "KDTdD2L2");
-  add_kdt_pyclass<double, 3, 1>(m, "KDTdD3L1");
-  add_kdt_pyclass<double, 3, 2>(m, "KDTdD3L2");
-  add_kdt_pyclass<double, 4, 1>(m, "KDTdD4L1");
-  add_kdt_pyclass<double, 4, 2>(m, "KDTdD4L2");
-  add_kdt_pyclass<double, 5, 1>(m, "KDTdD5L1");
-  add_kdt_pyclass<double, 5, 2>(m, "KDTdD5L2");
-  add_kdt_pyclass<double, 6, 1>(m, "KDTdD6L1");
-  add_kdt_pyclass<double, 6, 2>(m, "KDTdD6L2");
-  add_kdt_pyclass<double, 7, 1>(m, "KDTdD7L1");
-  add_kdt_pyclass<double, 7, 2>(m, "KDTdD7L2");
-  add_kdt_pyclass<double, 8, 1>(m, "KDTdD8L1");
-  add_kdt_pyclass<double, 8, 2>(m, "KDTdD8L2");
-  add_kdt_pyclass<double, 9, 1>(m, "KDTdD9L1");
-  add_kdt_pyclass<double, 9, 2>(m, "KDTdD9L2");
-  add_kdt_pyclass<double, 10, 1>(m, "KDTdD10L1");
-  add_kdt_pyclass<double, 10, 2>(m, "KDTdD10L2");
-  add_kdt_pyclass<double, 11, 1>(m, "KDTdD11L1");
-  add_kdt_pyclass<double, 11, 2>(m, "KDTdD11L2");
-  add_kdt_pyclass<double, 12, 1>(m, "KDTdD12L1");
-  add_kdt_pyclass<double, 12, 2>(m, "KDTdD12L2");
-  add_kdt_pyclass<double, 13, 1>(m, "KDTdD13L1");
-  add_kdt_pyclass<double, 13, 2>(m, "KDTdD13L2");
-  add_kdt_pyclass<double, 14, 1>(m, "KDTdD14L1");
-  add_kdt_pyclass<double, 14, 2>(m, "KDTdD14L2");
-  add_kdt_pyclass<double, 15, 1>(m, "KDTdD15L1");
-  add_kdt_pyclass<double, 15, 2>(m, "KDTdD15L2");
-  add_kdt_pyclass<double, 16, 1>(m, "KDTdD16L1");
-  add_kdt_pyclass<double, 16, 2>(m, "KDTdD16L2");
-  add_kdt_pyclass<double, 17, 1>(m, "KDTdD17L1");
-  add_kdt_pyclass<double, 17, 2>(m, "KDTdD17L2");
-  add_kdt_pyclass<double, 18, 1>(m, "KDTdD18L1");
-  add_kdt_pyclass<double, 18, 2>(m, "KDTdD18L2");
-  add_kdt_pyclass<double, 19, 1>(m, "KDTdD19L1");
-  add_kdt_pyclass<double, 19, 2>(m, "KDTdD19L2");
-  add_kdt_pyclass<double, 20, 1>(m, "KDTdD20L1");
-  add_kdt_pyclass<double, 20, 2>(m, "KDTdD20L2");
+  add_kdt_pyclass<double, 1>(m, "KDTdL1");
+  add_kdt_pyclass<double, 2>(m, "KDTdL2");
 }
 
 } // namespace napf

--- a/src/python/classes/float_trees.cpp
+++ b/src/python/classes/float_trees.cpp
@@ -3,46 +3,8 @@
 namespace napf {
 
 void init_float_trees(py::module_& m) {
-  add_kdt_pyclass<float, 1, 1>(m, "KDTfD1L1");
-  add_kdt_pyclass<float, 1, 2>(m, "KDTfD1L2");
-  add_kdt_pyclass<float, 2, 1>(m, "KDTfD2L1");
-  add_kdt_pyclass<float, 2, 2>(m, "KDTfD2L2");
-  add_kdt_pyclass<float, 3, 1>(m, "KDTfD3L1");
-  add_kdt_pyclass<float, 3, 2>(m, "KDTfD3L2");
-  add_kdt_pyclass<float, 4, 1>(m, "KDTfD4L1");
-  add_kdt_pyclass<float, 4, 2>(m, "KDTfD4L2");
-  add_kdt_pyclass<float, 5, 1>(m, "KDTfD5L1");
-  add_kdt_pyclass<float, 5, 2>(m, "KDTfD5L2");
-  add_kdt_pyclass<float, 6, 1>(m, "KDTfD6L1");
-  add_kdt_pyclass<float, 6, 2>(m, "KDTfD6L2");
-  add_kdt_pyclass<float, 7, 1>(m, "KDTfD7L1");
-  add_kdt_pyclass<float, 7, 2>(m, "KDTfD7L2");
-  add_kdt_pyclass<float, 8, 1>(m, "KDTfD8L1");
-  add_kdt_pyclass<float, 8, 2>(m, "KDTfD8L2");
-  add_kdt_pyclass<float, 9, 1>(m, "KDTfD9L1");
-  add_kdt_pyclass<float, 9, 2>(m, "KDTfD9L2");
-  add_kdt_pyclass<float, 10, 1>(m, "KDTfD10L1");
-  add_kdt_pyclass<float, 10, 2>(m, "KDTfD10L2");
-  add_kdt_pyclass<float, 11, 1>(m, "KDTfD11L1");
-  add_kdt_pyclass<float, 11, 2>(m, "KDTfD11L2");
-  add_kdt_pyclass<float, 12, 1>(m, "KDTfD12L1");
-  add_kdt_pyclass<float, 12, 2>(m, "KDTfD12L2");
-  add_kdt_pyclass<float, 13, 1>(m, "KDTfD13L1");
-  add_kdt_pyclass<float, 13, 2>(m, "KDTfD13L2");
-  add_kdt_pyclass<float, 14, 1>(m, "KDTfD14L1");
-  add_kdt_pyclass<float, 14, 2>(m, "KDTfD14L2");
-  add_kdt_pyclass<float, 15, 1>(m, "KDTfD15L1");
-  add_kdt_pyclass<float, 15, 2>(m, "KDTfD15L2");
-  add_kdt_pyclass<float, 16, 1>(m, "KDTfD16L1");
-  add_kdt_pyclass<float, 16, 2>(m, "KDTfD16L2");
-  add_kdt_pyclass<float, 17, 1>(m, "KDTfD17L1");
-  add_kdt_pyclass<float, 17, 2>(m, "KDTfD17L2");
-  add_kdt_pyclass<float, 18, 1>(m, "KDTfD18L1");
-  add_kdt_pyclass<float, 18, 2>(m, "KDTfD18L2");
-  add_kdt_pyclass<float, 19, 1>(m, "KDTfD19L1");
-  add_kdt_pyclass<float, 19, 2>(m, "KDTfD19L2");
-  add_kdt_pyclass<float, 20, 1>(m, "KDTfD20L1");
-  add_kdt_pyclass<float, 20, 2>(m, "KDTfD20L2");
+  add_kdt_pyclass<float, 1>(m, "KDTfL1");
+  add_kdt_pyclass<float, 2>(m, "KDTfL2");
 }
 
 } // namespace napf

--- a/src/python/classes/int_trees.cpp
+++ b/src/python/classes/int_trees.cpp
@@ -3,46 +3,8 @@
 namespace napf {
 
 void init_int_trees(py::module_& m) {
-  add_kdt_pyclass<int32_t, 1, 1>(m, "KDTiD1L1");
-  add_kdt_pyclass<int32_t, 1, 2>(m, "KDTiD1L2");
-  add_kdt_pyclass<int32_t, 2, 1>(m, "KDTiD2L1");
-  add_kdt_pyclass<int32_t, 2, 2>(m, "KDTiD2L2");
-  add_kdt_pyclass<int32_t, 3, 1>(m, "KDTiD3L1");
-  add_kdt_pyclass<int32_t, 3, 2>(m, "KDTiD3L2");
-  add_kdt_pyclass<int32_t, 4, 1>(m, "KDTiD4L1");
-  add_kdt_pyclass<int32_t, 4, 2>(m, "KDTiD4L2");
-  add_kdt_pyclass<int32_t, 5, 1>(m, "KDTiD5L1");
-  add_kdt_pyclass<int32_t, 5, 2>(m, "KDTiD5L2");
-  add_kdt_pyclass<int32_t, 6, 1>(m, "KDTiD6L1");
-  add_kdt_pyclass<int32_t, 6, 2>(m, "KDTiD6L2");
-  add_kdt_pyclass<int32_t, 7, 1>(m, "KDTiD7L1");
-  add_kdt_pyclass<int32_t, 7, 2>(m, "KDTiD7L2");
-  add_kdt_pyclass<int32_t, 8, 1>(m, "KDTiD8L1");
-  add_kdt_pyclass<int32_t, 8, 2>(m, "KDTiD8L2");
-  add_kdt_pyclass<int32_t, 9, 1>(m, "KDTiD9L1");
-  add_kdt_pyclass<int32_t, 9, 2>(m, "KDTiD9L2");
-  add_kdt_pyclass<int32_t, 10, 1>(m, "KDTiD10L1");
-  add_kdt_pyclass<int32_t, 10, 2>(m, "KDTiD10L2");
-  add_kdt_pyclass<int32_t, 11, 1>(m, "KDTiD11L1");
-  add_kdt_pyclass<int32_t, 11, 2>(m, "KDTiD11L2");
-  add_kdt_pyclass<int32_t, 12, 1>(m, "KDTiD12L1");
-  add_kdt_pyclass<int32_t, 12, 2>(m, "KDTiD12L2");
-  add_kdt_pyclass<int32_t, 13, 1>(m, "KDTiD13L1");
-  add_kdt_pyclass<int32_t, 13, 2>(m, "KDTiD13L2");
-  add_kdt_pyclass<int32_t, 14, 1>(m, "KDTiD14L1");
-  add_kdt_pyclass<int32_t, 14, 2>(m, "KDTiD14L2");
-  add_kdt_pyclass<int32_t, 15, 1>(m, "KDTiD15L1");
-  add_kdt_pyclass<int32_t, 15, 2>(m, "KDTiD15L2");
-  add_kdt_pyclass<int32_t, 16, 1>(m, "KDTiD16L1");
-  add_kdt_pyclass<int32_t, 16, 2>(m, "KDTiD16L2");
-  add_kdt_pyclass<int32_t, 17, 1>(m, "KDTiD17L1");
-  add_kdt_pyclass<int32_t, 17, 2>(m, "KDTiD17L2");
-  add_kdt_pyclass<int32_t, 18, 1>(m, "KDTiD18L1");
-  add_kdt_pyclass<int32_t, 18, 2>(m, "KDTiD18L2");
-  add_kdt_pyclass<int32_t, 19, 1>(m, "KDTiD19L1");
-  add_kdt_pyclass<int32_t, 19, 2>(m, "KDTiD19L2");
-  add_kdt_pyclass<int32_t, 20, 1>(m, "KDTiD20L1");
-  add_kdt_pyclass<int32_t, 20, 2>(m, "KDTiD20L2");
+  add_kdt_pyclass<int32_t, 1>(m, "KDTiL1");
+  add_kdt_pyclass<int32_t, 2>(m, "KDTiL2");
 }
 
 } // namespace napf

--- a/src/python/classes/long_trees.cpp
+++ b/src/python/classes/long_trees.cpp
@@ -3,46 +3,8 @@
 namespace napf {
 
 void init_long_trees(py::module_& m) {
-  add_kdt_pyclass<int64_t, 1, 1>(m, "KDTlD1L1");
-  add_kdt_pyclass<int64_t, 1, 2>(m, "KDTlD1L2");
-  add_kdt_pyclass<int64_t, 2, 1>(m, "KDTlD2L1");
-  add_kdt_pyclass<int64_t, 2, 2>(m, "KDTlD2L2");
-  add_kdt_pyclass<int64_t, 3, 1>(m, "KDTlD3L1");
-  add_kdt_pyclass<int64_t, 3, 2>(m, "KDTlD3L2");
-  add_kdt_pyclass<int64_t, 4, 1>(m, "KDTlD4L1");
-  add_kdt_pyclass<int64_t, 4, 2>(m, "KDTlD4L2");
-  add_kdt_pyclass<int64_t, 5, 1>(m, "KDTlD5L1");
-  add_kdt_pyclass<int64_t, 5, 2>(m, "KDTlD5L2");
-  add_kdt_pyclass<int64_t, 6, 1>(m, "KDTlD6L1");
-  add_kdt_pyclass<int64_t, 6, 2>(m, "KDTlD6L2");
-  add_kdt_pyclass<int64_t, 7, 1>(m, "KDTlD7L1");
-  add_kdt_pyclass<int64_t, 7, 2>(m, "KDTlD7L2");
-  add_kdt_pyclass<int64_t, 8, 1>(m, "KDTlD8L1");
-  add_kdt_pyclass<int64_t, 8, 2>(m, "KDTlD8L2");
-  add_kdt_pyclass<int64_t, 9, 1>(m, "KDTlD9L1");
-  add_kdt_pyclass<int64_t, 9, 2>(m, "KDTlD9L2");
-  add_kdt_pyclass<int64_t, 10, 1>(m, "KDTlD10L1");
-  add_kdt_pyclass<int64_t, 10, 2>(m, "KDTlD10L2");
-  add_kdt_pyclass<int64_t, 11, 1>(m, "KDTlD11L1");
-  add_kdt_pyclass<int64_t, 11, 2>(m, "KDTlD11L2");
-  add_kdt_pyclass<int64_t, 12, 1>(m, "KDTlD12L1");
-  add_kdt_pyclass<int64_t, 12, 2>(m, "KDTlD12L2");
-  add_kdt_pyclass<int64_t, 13, 1>(m, "KDTlD13L1");
-  add_kdt_pyclass<int64_t, 13, 2>(m, "KDTlD13L2");
-  add_kdt_pyclass<int64_t, 14, 1>(m, "KDTlD14L1");
-  add_kdt_pyclass<int64_t, 14, 2>(m, "KDTlD14L2");
-  add_kdt_pyclass<int64_t, 15, 1>(m, "KDTlD15L1");
-  add_kdt_pyclass<int64_t, 15, 2>(m, "KDTlD15L2");
-  add_kdt_pyclass<int64_t, 16, 1>(m, "KDTlD16L1");
-  add_kdt_pyclass<int64_t, 16, 2>(m, "KDTlD16L2");
-  add_kdt_pyclass<int64_t, 17, 1>(m, "KDTlD17L1");
-  add_kdt_pyclass<int64_t, 17, 2>(m, "KDTlD17L2");
-  add_kdt_pyclass<int64_t, 18, 1>(m, "KDTlD18L1");
-  add_kdt_pyclass<int64_t, 18, 2>(m, "KDTlD18L2");
-  add_kdt_pyclass<int64_t, 19, 1>(m, "KDTlD19L1");
-  add_kdt_pyclass<int64_t, 19, 2>(m, "KDTlD19L2");
-  add_kdt_pyclass<int64_t, 20, 1>(m, "KDTlD20L1");
-  add_kdt_pyclass<int64_t, 20, 2>(m, "KDTlD20L2");
+  add_kdt_pyclass<int64_t, 1>(m, "KDTlL1");
+  add_kdt_pyclass<int64_t, 2>(m, "KDTlL2");
 }
 
 } // namespace napf

--- a/src/python/pykdt.hpp
+++ b/src/python/pykdt.hpp
@@ -30,14 +30,7 @@ using IndexType = typename UIntVector::value_type;
 using IndexVector = UIntVector;
 using IndexVectorVector = UIntVectorVector;
 
-template<typename DataT,
-         typename DistT,
-         typename IndexT,
-         int dim,
-         unsigned int metric>
-using TreeType = ArrayTree<DataT, DistT, IndexT, dim, metric>;
-
-template<typename DataT, size_t dim, unsigned int metric>
+template<typename DataT, unsigned int metric>
 class PyKDT {
 public:
   // let's fix some datatype.
@@ -54,10 +47,10 @@ public:
                                 FloatVectorVector,
                                 DoubleVectorVector>::type;
 
-  using Tree = TreeType<DataT, DistT, IndexType, dim, metric>;
-  using Cloud = napf::ArrayCloud<DataT, IndexType, dim>;
+  using Tree = ArrayTree<DataT, DistT, IndexType, metric>;
+  using Cloud = napf::ArrayCloud<DataT, IndexType>;
 
-  const int dim_ = dim;
+  int dim_{};
   const unsigned int metric_ = metric;
   size_t leaf_size_{10};
   int nthread_{1};
@@ -84,6 +77,7 @@ public:
                const size_t leaf_size = 10,
                const int nthread = 1) {
     // save settings
+    dim_ = tree_data.shape(1);
     leaf_size_ = leaf_size;
     nthread_ = nthread;
 
@@ -106,8 +100,8 @@ public:
 
     // prepare cloud and tree
     cloud_ = std::unique_ptr<Cloud>(
-        new Cloud(tree_data_ptr_, static_cast<IndexType>(t_buf.size)));
-    tree_ = std::unique_ptr<Tree>(new Tree(dim, *cloud_, params));
+        new Cloud(tree_data_ptr_, static_cast<IndexType>(t_buf.size), dim_));
+    tree_ = std::unique_ptr<Tree>(new Tree(dim_, *cloud_, params));
   }
 
   /* given query points, returns indices and distances */
@@ -140,7 +134,7 @@ public:
     // prepare routine in lambda so that it can be executed with nthreads
     auto searchknn = [&](int begin, int end, int) {
       for (int i{begin}; i < end; i++) {
-        const int j{i * static_cast<int>(dim)};
+        const int j{i * dim_};
         const int k{i * kneighbors};
         tree_->knnSearch(&q_buf_ptr[j],
                          kneighbors,
@@ -294,7 +288,7 @@ public:
     IndexType* o_i_ptr =
         static_cast<IndexType*>(original_inverse.request().ptr);
 
-    const IndexType index_t_dim{static_cast<IndexType>(dim)};
+    const IndexType index_t_dim{static_cast<IndexType>(dim_)};
     auto searchradius = [&](int start, int end, int current_tid) {
       for (IndexType i{static_cast<IndexType>(start)};
            i < static_cast<IndexType>(end);
@@ -404,9 +398,9 @@ public:
   }
 };
 
-template<typename T, int dim, unsigned int metric>
+template<typename T, unsigned int metric>
 void add_kdt_pyclass(py::module_& m, const char* class_name) {
-  using KDT = PyKDT<T, dim, metric>;
+  using KDT = PyKDT<T, metric>;
 
   py::class_<KDT> klasse(m, class_name);
 

--- a/src/python/pykdt.hpp
+++ b/src/python/pykdt.hpp
@@ -35,10 +35,7 @@ template<typename DataT,
          typename IndexT,
          int dim,
          unsigned int metric>
-using TreeType = typename std::conditional<
-    (dim < 4),
-    napf::RawPtrTree<DataT, DistT, IndexT, dim, metric>,
-    napf::RawPtrHighDimTree<DataT, DistT, IndexT, dim, metric>>::type;
+using TreeType = ArrayTree<DataT, DistT, IndexT, dim, metric>;
 
 template<typename DataT, size_t dim, unsigned int metric>
 class PyKDT {
@@ -58,7 +55,7 @@ public:
                                 DoubleVectorVector>::type;
 
   using Tree = TreeType<DataT, DistT, IndexType, dim, metric>;
-  using Cloud = napf::RawPtrCloud<DataT, IndexType, dim>;
+  using Cloud = napf::ArrayCloud<DataT, IndexType, dim>;
 
   const int dim_ = dim;
   const unsigned int metric_ = metric;

--- a/tests/test_init_and_query.py
+++ b/tests/test_init_and_query.py
@@ -58,6 +58,22 @@ class InitAndQueryTest(unittest.TestCase):
             assert np.isclose(dist[0], 0), f"wrong dist query for {qname}"
             assert ids[0] == n_data, f"wrong index query for {qname}"
 
+            # test knn_search
+            dist, ids = kdt.knn_search(kdt.tree_data, 1, nthread=2)
+            assert np.isclose(
+                dist.sum(), 0
+            ), f"wrong dist query for {qname}, dim {d}"
+
+            # skip integer types for index check
+            # as it is too easy for them to have duplicates.
+            # with default options of nanoflann, this will return smaller index
+            if dt.startswith("int"):
+                continue
+
+            assert np.all(
+                ids.ravel() == np.arange(len(kdt.tree_data))
+            ), f"wrong index query for {qname}, dim {d}"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Removes splinepy coordinate type based clouds and trees, as a preparation step for more dynamic proximity query.
- Removes dim as tparam, which makes the tree even more flexible and reduces explicit instantiation dramatically. This also has a benefit that the tree dimension is not limited by instantiated dimension. More importantly, the tree's dim is determined during init, so shouldn't have much effect.
- For L2_metric, we only use `nanoflann::L2_Simple_Adaptor`. Unlike `L2_Adaptor`, it computes metric with simple for loop. It has been told that kdtree is not so efficient in high dim, and if anything `L2_Adaptor` is useful for dim > 4. Thus, the decision to use only `L2_Simple_Adaptor`